### PR TITLE
Support external static clinet registration server

### DIFF
--- a/oidc_example/op2/server.py
+++ b/oidc_example/op2/server.py
@@ -13,6 +13,7 @@ from exceptions import AttributeError
 from exceptions import KeyboardInterrupt
 from urlparse import parse_qs
 from saml2 import BINDING_HTTP_REDIRECT, BINDING_HTTP_POST
+from oic.utils import shelve_wrapper
 from oic.utils.authn.javascript_login import JavascriptFormMako
 
 from oic.utils.authn.client import verify_client
@@ -391,7 +392,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Client data base
-    cdb = shelve.open("client_db", writeback=True)
+    cdb = shelve_wrapper.open("client_db", writeback=True)
 
     sys.path.insert(0, ".")
     config = importlib.import_module(args.config)

--- a/src/oic/utils/shelve_wrapper.py
+++ b/src/oic/utils/shelve_wrapper.py
@@ -1,0 +1,63 @@
+from shelve import Shelf
+import anydbm
+import shelve
+
+__author__ = 'danielevertsson'
+
+class ShelfWrapper(Shelf):
+
+    def __init__(self, filename, flag='c', protocol=None, writeback=False):
+        self.filename = filename
+        self.flag = flag
+
+        Shelf.__init__(self, anydbm.open(filename, flag), protocol, writeback)
+
+    def keys(self):
+        dict = self._reopen_database()
+        return dict.keys()
+
+    def __len__(self):
+        dict = self._reopen_database()
+        return dict.__len__()
+
+    def has_key(self, key):
+        dict = self._reopen_database()
+        return dict.has_key(key)
+
+    def __contains__(self, key):
+        dict = self._reopen_database()
+        return dict.__contains__(key)
+
+    def get(self, key, default=None):
+        dict = self._reopen_database()
+        return dict.get(key, default)
+
+    def __getitem__(self, key):
+        dict = self._reopen_database()
+        return dict.__getitem__(key)
+
+    def __setitem__(self, key, value):
+        dict = self._reopen_database()
+        dict.__setitem__(key, value)
+
+    def __delitem__(self, key):
+        dict = self._reopen_database()
+        dict.__delitem__(key)
+
+    def _reopen_database(self):
+        return shelve.open(self.filename, writeback=True)
+
+def open(filename, flag='c', protocol=None, writeback=False):
+    """Open a persistent dictionary for reading and writing.
+
+    The filename parameter is the base filename for the underlying
+    database.  As a side-effect, an extension may be added to the
+    filename and more than one file may be created.  The optional flag
+    parameter has the same interpretation as the flag parameter of
+    anydbm.open(). The optional protocol parameter specifies the
+    version of the pickle protocol (0, 1, or 2).
+
+    See the module's __doc__ string for an overview of the interface.
+    """
+
+    return ShelfWrapper(filename, flag, protocol, writeback)


### PR DESCRIPTION
Added a shelve_wrapper which is needed by the OP to get access to an up to date client_db if the database is modified by an external process.