### PR TITLE
Remove keys() from SessionDB

### DIFF
--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -193,9 +193,6 @@ class SessionDB(object):
         # Delete the mapping for session id
         self.uid2sid = {k: v for k, v in self.uid2sid.iteritems() if sid not in v}
 
-    def keys(self):
-        return self._db.keys()
-
     def update(self, key, attribute, value):
         if key in self._db:
             pass

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -276,7 +276,6 @@ class TestOICConsumer():
         result = self.consumer.do_authorization_request(
             state=_state, request_args=args)
 
-        print self.consumer.sdb.keys()
         print self.consumer.sdb["state0"].keys()
         part = self.consumer.parse_authz(query=result.headers["location"])
         print part


### PR DESCRIPTION
This is not used anywhere and may be hard or even impossible to
implement with some DBs