### PR TITLE
Remove unused Endpoint code

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -970,7 +970,7 @@ class Provider(AProvider):
         else:
             uireq = self.server.parse_user_info_request(data=request)
             logger.debug("user_info_request: %s" % uireq)
-            _token = uireq["access_token"]
+            _token = uireq["access_token"].replace(' ', '+')
 
         # should be an access token
         typ, key = _sdb.token.type_and_key(_token)


### PR DESCRIPTION
This "Endpoint" class is unused here, since provider importing Endpoint from the following module:
```
from oic.oauth2.provider import Endpoint
```