### PR TITLE
Fix access_token unquote issue

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -970,7 +970,7 @@ class Provider(AProvider):
         else:
             uireq = self.server.parse_user_info_request(data=request)
             logger.debug("user_info_request: %s" % uireq)
-            _token = uireq["access_token"]
+            _token = uireq["access_token"].replace(' ', '+')
 
         # should be an access token
         typ, key = _sdb.token.type_and_key(_token)


### PR DESCRIPTION
There is an issue on the user endpoint when it tries parse userinfo_request, it replace '+' character to ' ' for access_token which causes a problem in retrieving type and key from access token.

```
uireq = self.server.parse_user_info_request(data=request)
|--- request().from_urlencoded(query)
|------- urlparse.parse_qs(urlencoded)
|-------------- unquote(nv[1].replace('+', ' '))
```

If you follow the ```parse_user_info_request``` method, you will find that for access_token ```urlparse``` library replace '+' with space. That creates a problem in the following line:

```
typ, key = _sdb.token.type_and_key(_token)
```