### PR TITLE
Updated sub creation

### DIFF
--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -578,14 +578,14 @@ class Provider(object):
                         else:
                             return authn(**authn_args)
 
-        authn_event = AuthnEvent(identity["uid"], authn_info=authn_class_ref,
+        authn_event = AuthnEvent(identity["uid"], identity.get('salt', ''), authn_info=authn_class_ref,
                                  time_stamp=_ts)
 
         return {"authn_event": authn_event, "identity": identity, "user": user}
 
     def setup_session(self, areq, authn_event, cinfo):
         sid = self.sdb.create_authz_session(authn_event, areq)
-        self.sdb.do_sub(sid)
+        self.sdb.do_sub(sid, '')
         return sid
 
     def authorization_endpoint(self, request="", cookie="", **kwargs):

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -627,7 +627,7 @@ class Provider(AProvider):
             except KeyError:
                 pass
 
-        self.sdb.do_sub(sid, **kwargs)
+        self.sdb.do_sub(sid, cinfo['client_salt'], **kwargs)
         return sid
 
     def authorization_endpoint(self, request="", cookie=None, **kwargs):
@@ -1380,7 +1380,8 @@ class Provider(AProvider):
             "registration_access_token": _rat,
             "registration_client_uri": "%s?client_id=%s" % (reg_enp, client_id),
             "client_secret_expires_at": utc_time_sans_frac() + 86400,
-            "client_id_issued_at": utc_time_sans_frac()}
+            "client_id_issued_at": utc_time_sans_frac(),
+            "client_salt": rndstr(8)}
 
         self.cdb[_rat] = client_id
 

--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -101,9 +101,9 @@ class MyFakeOICServer(Server):
 
     def authorization_endpoint(self, query):
         req = self.parse_authorization_request(query=query)
-        aevent = AuthnEvent("user", authn_info="acr")
+        aevent = AuthnEvent("user", "salt", authn_info="acr")
         sid = self.sdb.create_authz_session(aevent, areq=req)
-        _ = self.sdb.do_sub(sid)
+        _ = self.sdb.do_sub(sid, "client_salt")
         _info = self.sdb[sid]
 
         if "code" in req["response_type"]:

--- a/tests/mitmsrv.py
+++ b/tests/mitmsrv.py
@@ -100,9 +100,9 @@ class MITMServer(Server):
 
     def authorization_endpoint(self, query):
         req = self.parse_authorization_request(query=query)
-        aevent = AuthnEvent("user", authn_info="acr")
+        aevent = AuthnEvent("user", "salt", authn_info="acr")
         sid = self.sdb.create_authz_session(aevent, areq=req)
-        _ = self.sdb.do_sub(sid)
+        _ = self.sdb.do_sub(sid, 'client_salt')
         _info = self.sdb[sid]
 
         if "code" in req["response_type"]:

--- a/tests/oic/oic/test_oic_provider.py
+++ b/tests/oic/oic/test_oic_provider.py
@@ -90,17 +90,21 @@ CDB = {
         "password": "hemligt",
         "client_secret": "drickyoughurt",
         "redirect_uris": [("http://localhost:8087/authz", None)],
-        "post_logout_redirect_uris": [("https://example.com/post_logout", None)]
+        "post_logout_redirect_uris": [("https://example.com/post_logout", None)],
+        "client_salt": "salted"
     },
     "a1b2c3": {
-        "redirect_uris": [("http://localhost:8087/authz", None)]
+        "redirect_uris": [("http://localhost:8087/authz", None)],
+        "client_salt": "salted"
     },
     "client0": {
-        "redirect_uris": [("http://www.example.org/authz", None)]
+        "redirect_uris": [("http://www.example.org/authz", None)],
+        "client_salt": "salted"
     },
     CLIENT_ID: {
         "client_secret": CLIENT_SECRET,
-        "redirect_uris": [("http://localhost:8087/authz", None)]
+        "redirect_uris": [("http://localhost:8087/authz", None)],
+        "client_salt": "salted"
     }
 }
 
@@ -212,9 +216,9 @@ class TestProvider(object):
                                     scope=["openid"], state="state000")
 
         sdb = self.provider.sdb
-        ae = AuthnEvent("userX")
+        ae = AuthnEvent("userX", "salt")
         sid = sdb.create_authz_session(ae, areq)
-        sdb.do_sub(sid)
+        sdb.do_sub(sid, "client_salt")
         _info = sdb[sid]
         # All this is jut removed when the id_token is constructed
         # The proper information comes from the session information
@@ -341,7 +345,7 @@ class TestProvider(object):
         _sdb = self.provider.sdb
         sid = _sdb.token.key(user="sub", areq=authreq)
         access_grant = _sdb.token(sid=sid)
-        ae = AuthnEvent("user")
+        ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "oauth_state": "authz",
             "authn_event": ae,
@@ -352,7 +356,7 @@ class TestProvider(object):
             "scope": ["openid"],
             "redirect_uri": "http://example.com/authz",
         }
-        _sdb.do_sub(sid)
+        _sdb.do_sub(sid, "client_salt")
 
         # Construct Access token request
         areq = AccessTokenRequest(code=access_grant, client_id=CLIENT_ID,
@@ -375,7 +379,7 @@ class TestProvider(object):
         _sdb = self.provider.sdb
         sid = _sdb.token.key(user="sub", areq=authreq)
         access_grant = _sdb.token(sid=sid)
-        ae = AuthnEvent("user")
+        ae = AuthnEvent("user", "salt")
         _sdb[sid] = {
             "authn_event": ae,
             "oauth_state": "authz",
@@ -386,7 +390,7 @@ class TestProvider(object):
             "scope": ["openid"],
             "redirect_uri": "http://example.com/authz"
         }
-        _sdb.do_sub(sid)
+        _sdb.do_sub(sid, "client_salt")
 
         # Construct Access token request
         areq = AccessTokenRequest(code=access_grant,
@@ -417,9 +421,9 @@ class TestProvider(object):
                                     redirect_uri="http://example.com/authz",
                                     scope=["openid"], state="state000")
 
-        ae = AuthnEvent("sub")
+        ae = AuthnEvent("sub", "salt")
         sid = self.provider.sdb.create_authz_session(ae, AREQ)
-        self.provider.sdb.do_sub(sid)
+        self.provider.sdb.do_sub(sid, "client_salt")
         session = self.provider.sdb[sid]
 
         id_token = self.provider.id_token_as_signed_jwt(session)
@@ -429,9 +433,9 @@ class TestProvider(object):
         areq = AuthorizationRequest(response_type="code", client_id=CLIENT_ID,
                                     redirect_uri="http://example.com/authz",
                                     scope=["openid"], state="state000")
-        aevent = AuthnEvent("sub")
+        aevent = AuthnEvent("sub", "salt")
         sid = self.provider.sdb.create_authz_session(aevent, areq)
-        self.provider.sdb.do_sub(sid)
+        self.provider.sdb.do_sub(sid, "client_salt")
         session = self.provider.sdb[sid]
 
         claims = {'k1': 'v1', 'k2': 32}


### PR DESCRIPTION
During client registration a random salt is generated and stored in
`cdb`. This is used in pairwise sub creation.
AuthnEvent now takes user-specific salt which can be returned from
authenticated_as() and is used in public and pairwise sub creation.