### PR TITLE
Access Token Response token_type value is case insensitive

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -702,7 +702,7 @@ class Client(oauth2.Client):
 
             if token.is_valid():
                 uir["access_token"] = token.access_token
-                if token.token_type == "Bearer" and method == "GET":
+                if token.token_type.lower() == "bearer" and method == "GET":
                     kwargs["behavior"] = "use_authorization_header"
             else:
                 # raise oauth2.OldAccessToken
@@ -734,7 +734,7 @@ class Client(oauth2.Client):
                     raise MissingParameter("Unspecified token type")
 
             # use_authorization_header, token_in_message_body
-            if "use_authorization_header" in _behav and _ttype == "Bearer":
+            if "use_authorization_header" in _behav and _ttype.lower() == "bearer":
                 bh = "Bearer %s" % _token
                 if "headers" in kwargs:
                     kwargs["headers"].update({"Authorization": bh})


### PR DESCRIPTION
According to section 4.2.2 of [RFC 6749](https://tools.ietf.org/html/rfc6749#section-4.2.2) the token_type
value is case insensitive.

In two places in oic/oic/\_\_init\_\_.py this value is checked against
using the string "Bearer" resulting in an exception when the auth
server response token_type value is "bearer".

Fix by applying lower() to the token_type value and compare with
"bearer".

We experienced this when experimenting with [Keycloak](http://keycloak.jboss.org/) for SSO.