### PR TITLE
Separated Refresh token storage

### DIFF
--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -152,7 +152,7 @@ class MyFakeOICServer(Server):
     def token_endpoint(self, data):
         if "grant_type=refresh_token" in data:
             req = self.parse_refresh_token_request(body=data)
-            _info = self.sdb.refresh_token(req["refresh_token"])
+            _info = self.sdb.refresh_token(req["refresh_token"], req['client_id'])
         elif "grant_type=authorization_code":
             req = self.parse_token_request(body=data)
             _info = self.sdb.upgrade_to_token(req["code"])

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -149,18 +149,18 @@ class TestClient(object):
 
     def test_do_access_token_refresh(self):
         args = {"response_type": ["code"],
-                "scope": ["openid"]}
+                "scope": ["openid", "offline"]}
         r = self.client.do_authorization_request(state="state0",
                                                  request_args=args)
         self.client.parse_response(AuthorizationResponse, r.headers["location"],
                                    sformat="urlencoded")
-        self.client.do_access_token_request(scope="openid",
+        self.client.do_access_token_request(scope="openid offline",
                                             state="state0")
 
-        resp = self.client.do_access_token_refresh(scope="openid",
+        resp = self.client.do_access_token_refresh(scope="openid offline",
                                                    state="state0")
         assert isinstance(resp, AccessTokenResponse)
-        assert _eq(resp.keys(), ['token_type', 'state', 'access_token',
+        assert _eq(resp.keys(), ['token_type', 'access_token',
                                  'expires_in', 'refresh_token', 'scope'])
 
     def test_do_check_session_request(self):


### PR DESCRIPTION
It is intended to be stored in non-volatile way to allow functionality
even if SessionDB had been restarted
Refresh token format changed to allow easier recognition