### PR TITLE
Refresh token disabled by default

### DIFF
--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -782,7 +782,7 @@ class Provider(object):
             assert areq["redirect_uri"] == _info["redirect_uri"]
 
         try:
-            _tinfo = _sdb.upgrade_to_token(areq["code"])
+            _tinfo = _sdb.upgrade_to_token(areq["code"], issue_refresh=True)
         except AccessCodeUsed:
             err = TokenErrorResponse(error="invalid_grant",
                                      error_description="Access grant used")

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -450,20 +450,14 @@ class AuthorizationRequest(message.AuthorizationRequest):
 
         _rt = self["response_type"]
         if "token" in _rt or "id_token" in _rt:
-            try:
-                assert "nonce" in self
-            except AssertionError:
+            if "nonce" not in self:
                 raise MissingRequiredAttribute("Nonce missing", self)
 
-        try:
-            assert "openid" in self["scope"]
-        except AssertionError:
+        if "openid" not in self["scope"]:
             raise MissingRequiredValue("openid not in scope", self)
 
         if "offline_access" in self["scope"]:
-            try:
-                assert "consent" in self["prompt"]
-            except AssertionError:
+            if "prompt" not in self or "consent" not in self["prompt"]:
                 raise MissingRequiredValue("consent in prompt", self)
 
         if "prompt" in self:

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -838,13 +838,16 @@ class Provider(AProvider):
 
         _log_debug("All checks OK")
 
+        issue_refresh = False
         if "issue_refresh" in kwargs:
-            args = {"issue_refresh": kwargs["issue_refresh"]}
-        else:
-            args = {}
+            issue_refresh = kwargs["issue_refresh"]
+
+        permissions = _info.get('permission', ['offline_access']) or ['offline_access']
+        if 'offline_access' in _info['scope'] and 'offline_access' in permissions:
+            issue_refresh = True
 
         try:
-            _sdb.upgrade_to_token(_access_code, **args)
+            _tinfo = _sdb.upgrade_to_token(_access_code, issue_refresh=issue_refresh)
         except Exception as err:
             logger.error("%s" % err)
             # Should revoke the token issued to this access code

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -310,7 +310,7 @@ class SessionDB(object):
         elif self._db[sid]["oauth_state"] == "token":
             return self._db[sid]["access_token"]
 
-    def upgrade_to_token(self, token=None, issue_refresh=True, id_token="",
+    def upgrade_to_token(self, token=None, issue_refresh=False, id_token="",
                          oidreq=None, key=None, access_grant=""):
         """
 

--- a/tests/fakeoicsrv.py
+++ b/tests/fakeoicsrv.py
@@ -109,7 +109,10 @@ class MyFakeOICServer(Server):
         if "code" in req["response_type"]:
             if "token" in req["response_type"]:
                 grant = _info["code"]
-                _dict = self.sdb.upgrade_to_token(grant)
+                if 'offline_access' in _info['scope']:
+                    _dict = self.sdb.upgrade_to_token(grant, issue_refresh=True)
+                else:
+                    _dict = self.sdb.upgrade_to_token(grant)
                 _dict["oauth_state"] = "authz",
 
                 _dict = by_schema(AuthorizationResponse(), **_dict)
@@ -155,7 +158,10 @@ class MyFakeOICServer(Server):
             _info = self.sdb.refresh_token(req["refresh_token"])
         elif "grant_type=authorization_code":
             req = self.parse_token_request(body=data)
-            _info = self.sdb.upgrade_to_token(req["code"])
+            if 'offline_access' in self.sdb[req['code']]['scope']:
+                _info = self.sdb.upgrade_to_token(req["code"], issue_refresh=True)
+            else:
+                _info = self.sdb.upgrade_to_token(req["code"])
         else:
             response = TokenErrorResponse(error="unsupported_grant_type")
             return response, ""

--- a/tests/test_oic.py
+++ b/tests/test_oic.py
@@ -128,7 +128,7 @@ class TestClient(object):
                                                    state="state0")
         assert isinstance(resp, AccessTokenResponse)
         assert _eq(resp.keys(), ['token_type', 'state', 'access_token',
-                                 'expires_in', 'refresh_token', 'scope'])
+                                 'expires_in', 'scope'])
 
     def test_do_user_info_request(self):
         resp = AuthorizationResponse(code="code", state="state")
@@ -149,15 +149,16 @@ class TestClient(object):
 
     def test_do_access_token_refresh(self):
         args = {"response_type": ["code"],
-                "scope": ["openid"]}
+                "scope": ["openid offline_access"],
+                "prompt": "consent"}
         r = self.client.do_authorization_request(state="state0",
                                                  request_args=args)
         self.client.parse_response(AuthorizationResponse, r.headers["location"],
                                    sformat="urlencoded")
-        self.client.do_access_token_request(scope="openid",
+        self.client.do_access_token_request(scope="openid offline_access",
                                             state="state0")
 
-        resp = self.client.do_access_token_refresh(scope="openid",
+        resp = self.client.do_access_token_refresh(scope="openid offline_access",
                                                    state="state0")
         assert isinstance(resp, AccessTokenResponse)
         assert _eq(resp.keys(), ['token_type', 'state', 'access_token',
@@ -208,15 +209,16 @@ class TestClient(object):
 
     def test_do_user_info_request_with_access_token_refresh(self):
         args = {"response_type": ["code"],
-                "scope": ["openid"]}
+                "scope": ["openid offline_access"],
+                "prompt": "consent"}
         r = self.client.do_authorization_request(state="state0",
                                                  request_args=args)
         self.client.parse_response(AuthorizationResponse, r.headers["location"],
                                    sformat="urlencoded")
-        self.client.do_access_token_request(scope="openid",
+        self.client.do_access_token_request(scope="openid offline_access",
                                             state="state0")
 
-        token = self.client.get_token(state="state0", scope="openid")
+        token = self.client.get_token(state="state0", scope="openid offline_access")
         token.token_expiration_time = utc_time_sans_frac() - 86400
 
         resp = self.client.do_user_info_request(state="state0")

--- a/tests/test_oic_consumer.py
+++ b/tests/test_oic_consumer.py
@@ -198,7 +198,7 @@ class TestOICConsumer():
         resp = self.consumer.complete(_state)
         assert isinstance(resp, AccessTokenResponse)
         assert _eq(resp.keys(), ['token_type', 'state', 'access_token',
-                                 'scope', 'expires_in', 'refresh_token'])
+                                 'scope', 'expires_in'])
 
         assert resp["state"] == _state
 
@@ -268,7 +268,7 @@ class TestOICConsumer():
         resp = self.consumer.complete(_state)
         assert isinstance(resp, AccessTokenResponse)
         assert _eq(resp.keys(), ['token_type', 'state', 'access_token',
-                                 'scope', 'expires_in', 'refresh_token'])
+                                 'scope', 'expires_in'])
 
         assert resp["state"] == _state
 
@@ -299,10 +299,9 @@ class TestOICConsumer():
         assert isinstance(auth, AuthorizationResponse)
         assert isinstance(acc, AccessTokenResponse)
         assert _eq(auth.keys(), ['code', 'access_token', 'expires_in',
-                                 'token_type', 'state', 'scope',
-                                 'refresh_token'])
+                                 'token_type', 'state', 'scope'])
         assert _eq(acc.keys(), ['token_type', 'state', 'access_token', 'scope',
-                                'expires_in', 'refresh_token'])
+                                'expires_in'])
 
     def test_complete_auth_token_idtoken(self):
         _state = "state0"

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -369,6 +369,43 @@ class TestProvider(object):
         atr = AccessTokenResponse().deserialize(resp.message, "json")
         assert _eq(atr.keys(),
                    ['token_type', 'id_token', 'access_token', 'scope',
+                    'expires_in'])
+
+    def test_token_endpoint_refresh(self):
+        authreq = AuthorizationRequest(state="state",
+                                       redirect_uri="http://example.com/authz",
+                                       client_id=CLIENT_ID,
+                                       response_type="code",
+                                       scope=["openid offline_access"],
+                                       prompt="consent")
+
+        _sdb = self.provider.sdb
+        sid = _sdb.token.key(user="sub", areq=authreq)
+        access_grant = _sdb.token(sid=sid)
+        ae = AuthnEvent("user", "salt")
+        _sdb[sid] = {
+            "oauth_state": "authz",
+            "authn_event": ae,
+            "authzreq": authreq.to_json(),
+            "client_id": CLIENT_ID,
+            "code": access_grant,
+            "code_used": False,
+            "scope": ["openid", "offline_access"],
+            "redirect_uri": "http://example.com/authz",
+        }
+        _sdb.do_sub(sid, "client_salt")
+
+        # Construct Access token request
+        areq = AccessTokenRequest(code=access_grant, client_id=CLIENT_ID,
+                                  redirect_uri="http://example.com/authz",
+                                  client_secret=CLIENT_SECRET)
+
+        txt = areq.to_urlencoded()
+
+        resp = self.provider.token_endpoint(request=txt)
+        atr = AccessTokenResponse().deserialize(resp.message, "json")
+        assert _eq(atr.keys(),
+                   ['token_type', 'id_token', 'access_token', 'scope',
                     'expires_in', 'refresh_token'])
 
     def test_token_endpoint_unauth(self):

--- a/tests/test_sdb.py
+++ b/tests/test_sdb.py
@@ -26,6 +26,11 @@ AREQN = AuthorizationRequest(response_type="code", client_id="client1",
                              scope=["openid"], state="state000",
                              nonce="something")
 
+AREQO = AuthorizationRequest(response_type="code", client_id="client1",
+                             redirect_uri="http://example.com/authz",
+                             scope=["openid", "offlien_access"],
+                             prompt="consent", state="state000")
+
 OIDR = OpenIDRequest(response_type="code", client_id="client1",
                      redirect_uri="http://example.com/authz", scope=["openid"],
                      state="state000")
@@ -162,6 +167,24 @@ class TestSessionDB(object):
                     'access_token', 'token_expires_at', 'expires_in',
                     'token_type', 'state', 'redirect_uri',
                     'code_used', 'client_id', 'scope', 'oauth_state',
+                    'access_token_scope'])
+
+        # can't update again
+        with pytest.raises(AccessCodeUsed):
+            self.sdb.upgrade_to_token(grant)
+            self.sdb.upgrade_to_token(_dict["access_token"])
+
+    def test_upgrade_to_token_refresh(self):
+        ae1 = AuthnEvent("sub", "salt")
+        sid = self.sdb.create_authz_session(ae1, AREQO)
+        grant = self.sdb[sid]["code"]
+        _dict = self.sdb.upgrade_to_token(grant, issue_refresh=True)
+
+        assert _eq(_dict.keys(),
+                   ['authn_event', 'code', 'authzreq', 'revoked',
+                    'access_token', 'token_expires_at', 'expires_in',
+                    'token_type', 'state', 'redirect_uri',
+                    'code_used', 'client_id', 'scope', 'oauth_state',
                     'refresh_token', 'access_token_scope'])
 
         # can't update again
@@ -181,21 +204,20 @@ class TestSessionDB(object):
                     'oidreq', 'access_token', 'id_token',
                     'token_expires_at', 'expires_in', 'token_type',
                     'state', 'redirect_uri', 'code_used', 'client_id',
-                    'scope', 'oauth_state', 'refresh_token',
-                    'access_token_scope'])
+                    'scope', 'oauth_state', 'access_token_scope'])
 
         assert _dict["id_token"] == "id_token"
         assert isinstance(_dict["oidreq"], OpenIDRequest)
 
     def test_refresh_token(self):
         ae = AuthnEvent("sub", "salt")
-        sid = self.sdb.create_authz_session(ae, AREQ)
+        sid = self.sdb.create_authz_session(ae, AREQO)
         grant = self.sdb[sid]["code"]
 
         with mock.patch("time.gmtime", side_effect=[
                 time.struct_time((1970, 1, 1, 10, 39, 0, 0, 0, 0)),
                 time.struct_time((1970, 1, 1, 10, 40, 0, 0, 0, 0))]):
-            dict1 = self.sdb.upgrade_to_token(grant).copy()
+            dict1 = self.sdb.upgrade_to_token(grant, issue_refresh=True).copy()
             rtoken = dict1["refresh_token"]
             dict2 = self.sdb.refresh_token(rtoken)
 
@@ -212,7 +234,7 @@ class TestSessionDB(object):
 
         assert self.sdb.is_valid(grant)
 
-        tokens = self.sdb.upgrade_to_token(grant)
+        tokens = self.sdb.upgrade_to_token(grant, issue_refresh=True)
         assert not self.sdb.is_valid(grant)
         access_token = tokens["access_token"]
         assert self.sdb.is_valid(access_token)
@@ -245,10 +267,10 @@ class TestSessionDB(object):
 
     def test_revoke_token(self):
         ae1 = AuthnEvent("sub", "salt")
-        sid = self.sdb.create_authz_session(ae1, AREQ)
+        sid = self.sdb.create_authz_session(ae1, AREQO)
 
         grant = self.sdb[sid]["code"]
-        tokens = self.sdb.upgrade_to_token(grant)
+        tokens = self.sdb.upgrade_to_token(grant, issue_refresh=True)
         access_token = tokens["access_token"]
         refresh_token = tokens["refresh_token"]
 


### PR DESCRIPTION
As a mean to access user data without his presence, it should be only issued
when offline_access is requested and allowed by user.

This is another attempt for a closed #111, I found a bug in my implementation. This should be working now.