### PR TITLE
Fix KeyError in _access_token_endpoint

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -826,7 +826,11 @@ class Provider(AProvider):
         if self.sdb.is_revoked(_access_code):
             return self._error(error="access_denied", descr="Token is revoked")
 
-        _info = _sdb[_access_code]
+        # Session might not exist or _access_code malformed
+        try:
+            _info = _sdb[_access_code]
+        except KeyError:
+            return self._error(error="access_denied", descr="Token is invalid")
 
         # If redirect_uri was in the initial authorization request
         # verify that the one given here is the correct one.

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -371,6 +371,41 @@ class TestProvider(object):
                    ['token_type', 'id_token', 'access_token', 'scope',
                     'expires_in', 'refresh_token'])
 
+    def test_token_endpoint_malformed(self):
+        authreq = AuthorizationRequest(state="state",
+                                       redirect_uri="http://example.com/authz",
+                                       client_id=CLIENT_ID,
+                                       response_type="code",
+                                       scope=["openid"])
+
+        _sdb = self.provider.sdb
+        sid = _sdb.token.key(user="sub", areq=authreq)
+        access_grant = _sdb.token(sid=sid)
+        ae = AuthnEvent("user", "salt")
+        _sdb[sid] = {
+            "oauth_state": "authz",
+            "authn_event": ae,
+            "authzreq": authreq.to_json(),
+            "client_id": CLIENT_ID,
+            "code": access_grant,
+            "code_used": False,
+            "scope": ["openid"],
+            "redirect_uri": "http://example.com/authz",
+        }
+        _sdb.do_sub(sid, "client_salt")
+
+        # Construct Access token request
+        areq = AccessTokenRequest(code=access_grant[0:len(access_grant)-1],
+                                  client_id=CLIENT_ID,
+                                  redirect_uri="http://example.com/authz",
+                                  client_secret=CLIENT_SECRET)
+
+        txt = areq.to_urlencoded()
+
+        resp = self.provider.token_endpoint(request=txt)
+        atr = TokenErrorResponse().deserialize(resp.message, "json")
+        assert atr['error'] == "access_denied"
+
     def test_token_endpoint_unauth(self):
         authreq = AuthorizationRequest(state="state",
                                        redirect_uri="http://example.com/authz",


### PR DESCRIPTION
_access_token can be malformed or the session might not exist at all.
This should result in error response and not in server error