### PR TITLE
Better falsy check for passing db kwarg to oic.utils.sdb:SessionDB

### DIFF
--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -260,7 +260,7 @@ class SessionDB(object):
                  token_expires_in=3600, password="4-amino-1H-pyrimidine-2-one",
                  grant_expires_in=600, seed="", refresh_db=None):
         self.base_url = base_url
-        if db:
+        if db is not None:
             self._db = db
         else:
             self._db = {}

--- a/src/oic/utils/sdb.py
+++ b/src/oic/utils/sdb.py
@@ -260,10 +260,9 @@ class SessionDB(object):
                  token_expires_in=3600, password="4-amino-1H-pyrimidine-2-one",
                  grant_expires_in=600, seed="", refresh_db=None):
         self.base_url = base_url
-        if db is not None:
-            self._db = db
-        else:
-            self._db = {}
+        if db is None:
+            db = {}
+        self._db = db
         if refresh_db:
             self._refresh_db = refresh_db
         else:


### PR DESCRIPTION
Without this change, if you do:
```python
db = dict()
sdb1 = SessionDB('iss1', db=db)
sdb2 = SessionDB('iss2', db=db)
```

Then `sdb1._db == sdb2._db` would not be True, but it should be. 