### PR TITLE
Produce ErrorResponse if scopes missing completely

### DIFF
--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -673,6 +673,12 @@ class Message(object):
     def __getitem__(self, item):
         return self._dict[item]
 
+    def get(self, item, default=None):
+        try:
+            return self[item]
+        except KeyError:
+            return default
+
     def items(self):
         return self._dict.items()
 

--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -453,10 +453,10 @@ class AuthorizationRequest(message.AuthorizationRequest):
             if "nonce" not in self:
                 raise MissingRequiredAttribute("Nonce missing", self)
 
-        if "openid" not in self["scope"]:
+        if "openid" not in self.get("scope", []):
             raise MissingRequiredValue("openid not in scope", self)
 
-        if "offline_access" in self["scope"]:
+        if "offline_access" in self.get("scope", []):
             if "prompt" not in self or "consent" not in self["prompt"]:
                 raise MissingRequiredValue("consent in prompt", self)
 

--- a/tests/test_oauth2_message.py
+++ b/tests/test_oauth2_message.py
@@ -149,6 +149,19 @@ class TestMessage(object):
         assert url_compare(req,
                            "http://example.com?req_str=Fair&req_str_list=game")
 
+    def test_get(self):
+        _dict = {"req_str": "Fair", "opt_str": "game", "opt_int": 9,
+                 "opt_str_list": ["one", "two"],
+                 "req_str_list": ["spike", "lee"],
+                 "opt_json": '{"ford": "green"}'}
+
+        cls = DummyMessage(**_dict)
+
+        assert cls.get("req_str") == "Fair"
+        assert cls.get("opt_int", 8) == 9
+        assert cls.get("missing") is None
+        assert cls.get("missing", []) == []
+
 
 class TestAuthorizationRequest(object):
     def test_authz_req_urlencoded(self):

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -15,6 +15,7 @@ from jwkest.jwk import SYMKey
 import pytest
 
 from oic.oauth2 import WrongSigningAlgorithm
+from oic.oauth2.message import MissingRequiredValue
 from oic.oic.message import ProviderConfigurationResponse
 from oic.oic.message import RegistrationResponse
 from oic.oic.message import AuthorizationRequest
@@ -320,6 +321,16 @@ class TestAuthorizationRequest(object):
 
         assert req["response_type"] == ["token", "id_token"]
         assert req["scope"] == ["openid", "profile"]
+
+    def test_verify_no_scopes(self):
+        args = {
+            "client_id": "foobar",
+            "redirect_uri": "http://foobar.example.com/oaclient",
+            "response_type": "code",
+        }
+        ar = AuthorizationRequest(**args)
+        with pytest.raises(MissingRequiredValue):
+            ar.verify()
 
 
 class TestAccessTokenResponse(object):


### PR DESCRIPTION
OIC verification fails with KeyError if scopes are missing completely.

It should instead produce an error message.