### PR TITLE
Registration Endpoint returns 201 Created not 200

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1496,7 +1496,7 @@ class Provider(AProvider):
 
         logger.debug("registration_response: %s" % response.to_dict())
 
-        return Response(response.to_json(), content="application/json",
+        return Response(response.to_json(), status='201 Created', content="application/json",
                         headers=[("Cache-Control", "no-store")])
 
     def registration_endpoint(self, request, authn=None, **kwargs):


### PR DESCRIPTION
https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationResponse

"A successful response SHOULD use the HTTP 201 Created status code"