### PR TITLE
Make Python 2 special case, not Python 3.

### DIFF
--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -488,10 +488,10 @@ class Client(oauth2.Client):
 
 
 def make_software_statement(keyjar, iss, **kwargs):
-    if six.PY3:
-        params = list(inspect.signature(JWT.__init__).parameters.keys())
-    else:
+    if six.PY2:
         params = inspect.getargspec(JWT.__init__).args
+    else:
+        params = list(inspect.signature(JWT.__init__).parameters.keys())
 
     params.remove('self')
 


### PR DESCRIPTION
See http://astrofrog.github.io/blog/2016/01/12/stop-writing-python-4-incompatible-code/.