### PR TITLE
Fix typo in error message.

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1371,7 +1371,7 @@ class Provider(AProvider):
                         "Http redirect_uri must use localhost")
             elif must_https and p.scheme != "https":
                 raise InvalidRedirectURIError(
-                    "None https redirect_uri not allowed")
+                    "Non-https redirect_uri not allowed")
             elif p.fragment:
                 raise InvalidRedirectURIError(
                     "redirect_uri contains fragment")

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -682,7 +682,7 @@ class TestProvider(object):
         with pytest.raises(InvalidRedirectURIError) as exc_info:
             self.provider._verify_redirect_uris(request)
 
-        assert str(exc_info.value) == "None https redirect_uri not allowed"
+        assert str(exc_info.value) == "Non-https redirect_uri not allowed"
 
     # @pytest.mark.network
     # def test_registration_endpoint_openid4us(self):


### PR DESCRIPTION
I ran into this error message working through https://github.com/rohe/ojou_course and didn't understand what it meant at first until I reviewed source. As soon as I realized it meant "non-https URL not allowed" it was easy to fix my problem.