### PR TITLE
Changed c to client for consistency

### DIFF
--- a/doc/howto/rp.rst
+++ b/doc/howto/rp.rst
@@ -30,7 +30,7 @@ So lets start with instantiating a client::
     from oic.oic import Client
     from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 
-    c = Client(client_authn_method=CLIENT_AUTHN_METHOD)
+    client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
 
 The first choice is really not yours. It's the OpenID Connect Provider (OP)
 that has to decide on whether it supports dynamic provider information


### PR DESCRIPTION
Everywhere else this variable is referenced, it's called `client`, so I thought it a good idea to keep it consistent.

One more note: changes to this document are not propagating to [readthedocs](http://pyoidc.readthedocs.org/) so [this page](http://pyoidc.readthedocs.org/en/latest/howto/rp.html) still has a very old version of this documentation.