### PR TITLE
FIx comb_uri

### DIFF
--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -1399,9 +1399,11 @@ class Provider(AProvider):
                 continue
 
             val = []
-            for base, query in args[param]:
-                if query:
-                    val.append("%s?%s" % (base, query))
+            for base, query_dict in args[param]:
+                if query_dict:
+                    query_string = urlencode(
+                        [(key, v) for key in query_dict for v in query_dict[key]])
+                    val.append("%s?%s" % (base, query_string))
                 else:
                     val.append(base)
 


### PR DESCRIPTION
I was having trouble registering clients with redirect_uris that have query strings
e.g. http://localhost:3000/authenticate?action=openid-connection-authorize

The response would come back like 
```
  "redirect_uris": [
    "http://localhost:8888/livefyre-portal/html/how-to-landing-page/?{u'action': [u'openid-connect-authorize']}"
  ],
```

This should fix it.