### PR TITLE
Issue #190 CAS login URI is /login.

### DIFF
--- a/src/oic/utils/authn/user_cas.py
+++ b/src/oic/utils/authn/user_cas.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # This class handles user authentication with CAS.
 class CasAuthnMethod(UserAuthnMethod):
     # Standard login url for a CAS server.
-    CONST_CASLOGIN = "/cas/login?"
+    CONST_CASLOGIN = "/login?"
     # Standard URL for validation of a ticket for a CAS server.
     CONST_CAS_VERIFY_TICKET = "/serviceValidate"
     # Standard name for the parameter containing a CAS ticket.


### PR DESCRIPTION
Fix CAS login URI per protocol spec.