### PR TITLE
Always call verify() in superclass first.

### DIFF
--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -947,6 +947,8 @@ class AuthorizationResponse(Message):
     }
 
     def verify(self, **kwargs):
+        super(AuthorizationResponse, self).verify(**kwargs)
+
         if 'client_id' in self:
             if self['client_id'] != kwargs['client_id']:
                 raise VerificationError('client_id mismatch')
@@ -959,7 +961,7 @@ class AuthorizationResponse(Message):
                 logger.info('No issuer set in the Client config')
                 pass
 
-        return super(AuthorizationResponse, self).verify(**kwargs)
+        return True
 
 
 class AccessTokenResponse(Message):

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -10,7 +10,7 @@ from jwkest import BadSignature
 from jwkest.jwk import SYMKey
 
 from oic.oauth2 import WrongSigningAlgorithm
-from oic.oauth2.message import MissingRequiredValue
+from oic.oauth2.message import MissingRequiredValue, MissingRequiredAttribute
 from oic.oic.message import ProviderConfigurationResponse
 from oic.oic.message import RegistrationResponse
 from oic.oic.message import AuthorizationRequest
@@ -336,7 +336,7 @@ class TestAuthorizationRequest(object):
             "response_type": "code",
         }
         ar = AuthorizationRequest(**args)
-        with pytest.raises(MissingRequiredValue):
+        with pytest.raises(MissingRequiredAttribute):
             ar.verify()
 
 


### PR DESCRIPTION
To make sure all required attributes are present, before any special handling is performed.