### PR TITLE
Client identifier is not required in RefreshAccessTokenRequest.

### DIFF
--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -1003,8 +1003,8 @@ class RefreshAccessTokenRequest(Message):
     c_param = {
         "grant_type": SINGLE_REQUIRED_STRING,
         "refresh_token": SINGLE_REQUIRED_STRING,
-        "client_id": SINGLE_REQUIRED_STRING,
         "scope": OPTIONAL_LIST_OF_SP_SEP_STRINGS,
+        "client_id": SINGLE_OPTIONAL_STRING,
         "client_secret": SINGLE_OPTIONAL_STRING
     }
     c_default = {"grant_type": "refresh_token"}


### PR DESCRIPTION
Will only be included in the request body for client authentication.