### PR TITLE
Don't truncate padding for HTTP Basic auth.

### DIFF
--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -106,8 +106,9 @@ class ClientSecretBasic(ClientAuthnMethod):
         if "headers" not in http_args:
             http_args["headers"] = {}
 
-        http_args["headers"]["Authorization"] = "Basic {}".format(
-            b64e_enc_dec("{}:{}".format(user, passwd), "utf-8", "utf-8"))
+        credentials = "{}:{}".format(user, passwd)
+        authz = base64.urlsafe_b64encode(credentials.encode("utf-8")).decode("utf-8")
+        http_args["headers"]["Authorization"] = "Basic {}".format(authz)
 
         try:
             del cis["client_secret"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -49,8 +49,16 @@ class TestClientSecretBasic(object):
         http_args = csb.construct(cis)
 
         assert http_args == {"headers": {"Authorization": "Basic {}".format(
-            base64.b64encode("A:boarding pass".encode("utf-8")).decode(
+            base64.urlsafe_b64encode("A:boarding pass".encode("utf-8")).decode(
                 "utf-8"))}}
+
+    def test_does_not_remove_padding(self):
+        cis = AccessTokenRequest(code="foo", redirect_uri="http://example.com")
+
+        csb = ClientSecretBasic(None)
+        http_args = csb.construct(cis, user="ab", password="c")
+
+        assert http_args["headers"]["Authorization"].endswith("==")
 
 
 class TestBearerHeader(object):


### PR DESCRIPTION
b64e_enc_dec removes any trailing '=', which should be left
for HTTP Basic auth.