### PR TITLE
Fixes parse_cookie() and cookie_parts()

### DIFF
--- a/src/oic/utils/http_util.py
+++ b/src/oic/utils/http_util.py
@@ -7,6 +7,7 @@ from future.backports.http.cookies import SimpleCookie
 from future.backports.urllib.parse import quote
 
 from jwkest import as_unicode
+from six import text_type
 
 from oic import rndstr
 
@@ -282,7 +283,7 @@ def parse_cookie(name, seed, kaka):
     if not kaka:
         return None
 
-    cookie_obj = SimpleCookie(kaka)
+    cookie_obj = SimpleCookie(text_type(kaka))
     morsel = cookie_obj.get(name)
 
     if morsel:
@@ -304,7 +305,7 @@ def parse_cookie(name, seed, kaka):
 
 
 def cookie_parts(name, kaka):
-    cookie_obj = SimpleCookie(kaka)
+    cookie_obj = SimpleCookie(text_type(kaka))
     morsel = cookie_obj.get(name)
     if morsel:
         return morsel.value.split("|")

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -6,6 +6,8 @@ from oic.utils.http_util import CookieDealer
 from oic.utils.http_util import Response
 from oic.utils.http_util import geturl
 from oic.utils.http_util import getpath
+from oic.utils.http_util import parse_cookie
+from oic.utils.http_util import cookie_parts
 
 __author__ = 'roland'
 
@@ -55,6 +57,25 @@ class TestCookieDealer(object):
         cookie_timestamp = datetime.datetime.strptime(
             cookie_expiration, "%a, %d-%b-%Y %H:%M:%S GMT")
         assert cookie_timestamp < now
+
+
+def test_parse_cookie():
+    kaka = ('pyoidc=bjmc::1463043535::upm|'
+            '1463043535|18a201305fa15a96ce4048e1fbb03f7715f86499')
+    seed = ''
+    name = 'pyoidc'
+    result = parse_cookie(name, seed, kaka)
+    assert result == ('bjmc::1463043535::upm', '1463043535')
+
+
+def test_cookie_parts():
+    name = 'pyoidc'
+    kaka = ('pyoidc=bjmc::1463043535::upm|'
+            '1463043535|18a201305fa15a96ce4048e1fbb03f7715f86499')
+    result = cookie_parts(name, kaka)
+    assert result == ['bjmc::1463043535::upm',
+                      '1463043535',
+                      '18a201305fa15a96ce4048e1fbb03f7715f86499']
 
 
 def test_geturl():


### PR DESCRIPTION
Fixes https://github.com/rohe/pyoidc/issues/202

This change avoids triggering an exception in `SimpleCookie()` when its passed a string type in Python 2.7. 