### PR TITLE
Convert 'bearer' to 'Bearer' for HTTP headers

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -759,7 +759,7 @@ class Client(oauth2.Client):
             else:
                 # use_authorization_header, token_in_message_body
                 if "use_authorization_header" in _behav:
-                    token_header = "{type} {token}".format(type=_ttype,
+                    token_header = "{type} {token}".format(type=_ttype.capitalize(),
                                                            token=_token)
                     if "headers" in kwargs:
                         kwargs["headers"].update({"Authorization": token_header})


### PR DESCRIPTION
Some software (like google) has strict requirements for it, and specification says `should` about `Bearer`. So converting any lowercase header here to capitalized. Headers like JWT or Someheader shall be untouched.
