### PR TITLE
After timeout, remote key is removed in case of 304 response #221:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,14 @@ with open('src/oic/__init__.py', 'r') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 setup(
-    name="oic",
+    name="ana-oic",
     version=version,
-    description="Python implementation of OAuth2 and OpenID Connect",
+    description="This is a patched package for Python implementation of OAuth2 "
+                "and OpenID Connect",
     author="Roland Hedberg",
     author_email="roland.hedberg@umu.se",
     license="Apache 2.0",
-    url='https://github.com/rohe/pyoidc',
+    url='https://github.com/fmoggia/pyoidc',
     packages=["oic", "oic/oauth2", "oic/oic", "oic/utils", "oic/utils/authn",
               "oic/utils/userinfo", 'oic/utils/rp', 'oic/extension'],
               # 'oic/v2'],

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -160,6 +160,13 @@ class KeyBundle(object):
         if r.status_code == 304:  # file has not changed
             self.time_out = time.time() + self.cache_time
             self.last_updated = time.time()
+            try:
+                self.do_keys(self.imp_jwks["keys"])
+            except KeyError:
+                logger.error("No 'keys' keyword in JWKS")
+                raise UpdateFailed(
+                    "Remote key update after 304 from '{}' failed.".format(
+                        self.source))
             return False
         elif r.status_code == 200:  # New content
             self.time_out = time.time() + self.cache_time


### PR DESCRIPTION
- Added logic that fills in the existing keys in case of a 304 response from the keys source.
