### PR TITLE
Verify the correct encryption params in RegistrationRequest.

### DIFF
--- a/src/oic/oic/message.py
+++ b/src/oic/oic/message.py
@@ -595,14 +595,16 @@ class RegistrationRequest(Message):
         if "initiate_login_uri" in self:
             assert self["initiate_login_uri"].startswith("https:")
 
-        for param in ["request_object", "id_token", "userinfo"]:
-            if "%s_encryption_alg" % param in self:
-                if "%s_encryption_enc" % param not in self:
-                    self["%s_encryption_enc" % param] = "A128CBC-HS256"
+        for param in ["request_object_encryption", "id_token_encrypted_response", "userinfo_encrypted_response"]:
+            alg_param = "%s_alg" % param
+            enc_param = "%s_enc" % param
+            if alg_param in self:
+                if enc_param not in self:
+                    self[enc_param] = "A128CBC-HS256"
 
             # both or none
-            if "%s_encryption_enc" % param in self:
-                assert "%s_encryption_alg" % param in self
+            if enc_param in self:
+                assert alg_param in self
 
         if "token_endpoint_auth_signing_alg" in self:
             assert self["token_endpoint_auth_signing_alg"] != "none"

--- a/tests/test_oic_message.py
+++ b/tests/test_oic_message.py
@@ -279,6 +279,16 @@ class TestRegistrationRequest(object):
         flattened_list_dict = {k: v[0] if isinstance(v, list) else v for k, v in expected_js_obj.items()}
         assert query_string_compare(req.to_urlencoded(), urlencode(flattened_list_dict))
 
+    @pytest.mark.parametrize("enc_param", [
+        "request_object_encryption_enc",
+        "id_token_encrypted_response_enc",
+        "userinfo_encrypted_response_enc",
+    ])
+    def test_registration_request_with_coupled_encryption_params(self, enc_param):
+        registration_params = {"redirect_uris": ["https://example.com/authz_cb"], enc_param: "RS25asdasd6"}
+        registration_req = RegistrationRequest(**registration_params)
+        with pytest.raises(AssertionError):
+            registration_req.verify()
 
 class TestRegistrationResponse(object):
     def test_deserialize(self):


### PR DESCRIPTION
Only 'request_object' ends with '_encryption_*', 'id_token' and
'userinfo' ends with '_encrypted_response_*'.