### PR TITLE
openid-connect-federation-1_0-01

### DIFF
--- a/oidc_fed/oidcfed.txt
+++ b/oidc_fed/oidcfed.txt
@@ -10,10 +10,10 @@
                                                                Microsoft
                                                               J. Bradley
                                                            Ping Identity
-                                                       September 7, 2016
+                                                       September 9, 2016
 
 
-                OpenID Connect Federation 1.0 - draft 02
+                OpenID Connect Federation 1.0 - draft 01
                      openid-connect-federation-1_0
 
 Abstract
@@ -53,7 +53,7 @@ Table of Contents
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 1]
+Hedberg, et al.          Expires March 13, 2017                 [Page 1]
 
                         OpenID Connect Federation         September 2016
 
@@ -109,7 +109,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 1]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 2]
+Hedberg, et al.          Expires March 13, 2017                 [Page 2]
 
                         OpenID Connect Federation         September 2016
 
@@ -165,7 +165,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 2]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 3]
+Hedberg, et al.          Expires March 13, 2017                 [Page 3]
 
                         OpenID Connect Federation         September 2016
 
@@ -221,7 +221,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 3]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 4]
+Hedberg, et al.          Expires March 13, 2017                 [Page 4]
 
                         OpenID Connect Federation         September 2016
 
@@ -277,7 +277,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 4]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 5]
+Hedberg, et al.          Expires March 13, 2017                 [Page 5]
 
                         OpenID Connect Federation         September 2016
 
@@ -333,7 +333,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 5]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 6]
+Hedberg, et al.          Expires March 13, 2017                 [Page 6]
 
                         OpenID Connect Federation         September 2016
 
@@ -389,7 +389,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 6]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 7]
+Hedberg, et al.          Expires March 13, 2017                 [Page 7]
 
                         OpenID Connect Federation         September 2016
 
@@ -445,7 +445,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 7]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 8]
+Hedberg, et al.          Expires March 13, 2017                 [Page 8]
 
                         OpenID Connect Federation         September 2016
 
@@ -501,7 +501,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 8]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                 [Page 9]
+Hedberg, et al.          Expires March 13, 2017                 [Page 9]
 
                         OpenID Connect Federation         September 2016
 
@@ -557,7 +557,7 @@ Hedberg, et al.          Expires March 11, 2017                 [Page 9]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 10]
+Hedberg, et al.          Expires March 13, 2017                [Page 10]
 
                         OpenID Connect Federation         September 2016
 
@@ -613,7 +613,7 @@ Hedberg, et al.          Expires March 11, 2017                [Page 10]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 11]
+Hedberg, et al.          Expires March 13, 2017                [Page 11]
 
                         OpenID Connect Federation         September 2016
 
@@ -669,7 +669,7 @@ Hedberg, et al.          Expires March 11, 2017                [Page 11]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 12]
+Hedberg, et al.          Expires March 13, 2017                [Page 12]
 
                         OpenID Connect Federation         September 2016
 
@@ -725,7 +725,7 @@ Hedberg, et al.          Expires March 11, 2017                [Page 12]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 13]
+Hedberg, et al.          Expires March 13, 2017                [Page 13]
 
                         OpenID Connect Federation         September 2016
 
@@ -781,7 +781,7 @@ Appendix A.  Example
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 14]
+Hedberg, et al.          Expires March 13, 2017                [Page 14]
 
                         OpenID Connect Federation         September 2016
 
@@ -837,7 +837,7 @@ A.1.1.  Step 1 - Developer creates its signing key pair.
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 15]
+Hedberg, et al.          Expires March 13, 2017                [Page 15]
 
                         OpenID Connect Federation         September 2016
 
@@ -893,7 +893,7 @@ A.1.2.  Step 2 - Developer submits registration data to FO
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 16]
+Hedberg, et al.          Expires March 13, 2017                [Page 16]
 
                         OpenID Connect Federation         September 2016
 
@@ -949,7 +949,7 @@ A.1.3.  Step 3 - FO returns a signed metadata statement
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 17]
+Hedberg, et al.          Expires March 13, 2017                [Page 17]
 
                         OpenID Connect Federation         September 2016
 
@@ -1005,7 +1005,7 @@ A.1.4.  Step 4 - The RP gets a signing key
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 18]
+Hedberg, et al.          Expires March 13, 2017                [Page 18]
 
                         OpenID Connect Federation         September 2016
 
@@ -1061,7 +1061,7 @@ A.1.5.  Step 5 - RP produces a client registration request
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 19]
+Hedberg, et al.          Expires March 13, 2017                [Page 19]
 
                         OpenID Connect Federation         September 2016
 
@@ -1117,7 +1117,7 @@ A.1.6.  Step 6 - Developer produces metadata statement for RP
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 20]
+Hedberg, et al.          Expires March 13, 2017                [Page 20]
 
                         OpenID Connect Federation         September 2016
 
@@ -1173,7 +1173,7 @@ A.1.7.  Step 7 - RP sends a client registration request to an OP
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 21]
+Hedberg, et al.          Expires March 13, 2017                [Page 21]
 
                         OpenID Connect Federation         September 2016
 
@@ -1229,7 +1229,7 @@ Appendix B.  Notices
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 22]
+Hedberg, et al.          Expires March 13, 2017                [Page 22]
 
                         OpenID Connect Federation         September 2016
 
@@ -1285,7 +1285,7 @@ Authors' Addresses
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 23]
+Hedberg, et al.          Expires March 13, 2017                [Page 23]
 
                         OpenID Connect Federation         September 2016
 
@@ -1341,4 +1341,4 @@ Hedberg, et al.          Expires March 11, 2017                [Page 23]
 
 
 
-Hedberg, et al.          Expires March 11, 2017                [Page 24]
+Hedberg, et al.          Expires March 13, 2017                [Page 24]

--- a/oidc_fed/oidcfed.xml
+++ b/oidc_fed/oidcfed.xml
@@ -25,7 +25,7 @@
   <front>
 
     <title abbrev="OpenID Connect Federation">OpenID Connect Federation 1.0 -
-      draft 02
+      draft 01
     </title>
 
     <author fullname="Roland Hedberg" role="editor" surname="Hedberg"
@@ -60,7 +60,7 @@
       </address>
     </author>
 
-    <date day="7" month="September" year="2016"/>
+    <date day="9" month="September" year="2016"/>
 
     <workgroup>OpenID Connect Working Group</workgroup>
 


### PR DESCRIPTION
This version updates the date to September 9th (the date of the last commits) and uses version number -01, since the last version published at openid.net/specs/ was -00.  This version has been published as http://openid.net/specs/openid-connect-federation-1_0-01.html.