### PR TITLE
Upgrade cryptography and cffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.5.0
-cryptography==0.6.1
-cffi==0.8.6
+cryptography==1.5.2
+cffi==1.8.3
 pyjwkest>=0.6.1
 mako>=1.0.0
 beaker>=1.6.4


### PR DESCRIPTION
Upgrades `cryptography` and `cffi` to >1.0 versions. Needed to fix https://github.com/pyca/cryptography/issues/2750 on Ubuntu 16.04.
