### PR TITLE
Sanitizes log entries to remove sensitive data

### DIFF
--- a/src/oic/extension/client.py
+++ b/src/oic/extension/client.py
@@ -20,6 +20,7 @@ from oic.oic import OIDCONF_PATTERN
 from oic.oic.message import AuthorizationResponse
 from oic.utils.http_util import SUCCESSFUL
 from oic.utils.keyio import KeyJar
+from oic.utils.sanitize import sanitize
 
 from oic.oauth2.message import ErrorResponse
 from oic.oauth2.exception import Unsupported
@@ -384,9 +385,9 @@ class Client(oauth2.Client):
                                     sformat="urlencoded",
                                     keyjar=self.keyjar)
         if aresp.type() == "ErrorResponse":
-            logger.info("ErrorResponse: %s" % aresp)
+            logger.info("ErrorResponse: %s" % sanitize(aresp))
             raise AuthzError(aresp.error)
 
-        logger.info("Aresp: %s" % aresp)
+        logger.info("Aresp: %s" % sanitize(aresp))
 
         return aresp

--- a/src/oic/extension/provider.py
+++ b/src/oic/extension/provider.py
@@ -60,6 +60,7 @@ from oic.utils.keyio import KeyBundle
 from oic.utils.keyio import KeyJar
 from oic.utils.keyio import key_export
 from oic.utils.sdb import AccessCodeUsed
+from oic.utils.sanitize import sanitize
 from oic.utils.time_util import utc_time_sans_frac
 from oic.utils.token_handler import NotAllowed
 from oic.utils.token_handler import TokenHandler
@@ -204,13 +205,14 @@ class Provider(provider.Provider):
         try:
             self.keyjar.load_keys(request, client_id)
             try:
-                logger.debug("keys for %s: [%s]" % (
-                    client_id,
-                    ",".join(["%s" % x for x in self.keyjar[client_id]])))
+                n_keys = len(self.keyjar[client_id])
+                msg = "Found {} keys for client_id={}"
+                logger.debug(msg.format(n_keys, client_id))
             except KeyError:
                 pass
         except Exception as err:
-            logger.error("Failed to load client keys: %s" % request.to_dict())
+            msg = "Failed to load client keys: {}"
+            logger.error(msg.format(sanitize(request.to_dict())))
             logger.error("%s", err)
             err = ClientRegistrationError(
                 error="invalid_configuration_parameter",

--- a/src/oic/oauth2/base.py
+++ b/src/oic/oauth2/base.py
@@ -7,6 +7,7 @@ from six.moves.http_cookies import SimpleCookie, CookieError
 from oic.oauth2.exception import NonFatalException
 from oic.oauth2.util import set_cookie
 from oic.utils.keyio import KeyJar
+from oic.utils.sanitize import sanitize
 
 __author__ = 'roland'
 
@@ -50,7 +51,7 @@ class PBase(object):
 
         if self.cookiejar:
             _kwargs["cookies"] = self._cookies()
-            logger.debug("SENT COOKIEs: %s" % (_kwargs["cookies"],))
+            logger.debug("SENT {} COOKIES" % (len(_kwargs["cookies"]),))
 
         if self.req_callback is not None:
             _kwargs = self.req_callback(method, url, **_kwargs)
@@ -60,7 +61,7 @@ class PBase(object):
         except Exception as err:
             logger.error(
                 "http_request failed: %s, url: %s, htargs: %s, method: %s" % (
-                    err, url, _kwargs, method))
+                    err, url, sanitize(_kwargs), method))
             raise
 
         if self.event_store is not None:
@@ -71,7 +72,7 @@ class PBase(object):
             # Telekom fix
             # set_cookie = set_cookie.replace(
             # "=;Path=/;Expires=Thu, 01-Jan-1970 00:00:01 GMT;HttpOnly,", "")
-            logger.debug("RECEIVED COOKIEs: %s" % _cookie)
+            logger.debug("RECEIVED COOKIE")
             try:
                 set_cookie(self.cookiejar, SimpleCookie(_cookie))
             except CookieError as err:

--- a/src/oic/oauth2/consumer.py
+++ b/src/oic/oauth2/consumer.py
@@ -10,6 +10,7 @@ from oic.oauth2.message import Message
 from oic.oauth2.message import AccessTokenResponse
 from oic.oauth2.message import AccessTokenRequest
 from oic.utils import http_util
+from oic.utils.sanitize import sanitize
 from oic.oauth2 import Client
 from oic.oauth2 import Grant
 from oic import rndstr
@@ -21,8 +22,6 @@ ENDPOINTS = ["authorization_endpoint", "token_endpoint", "userinfo_endpoint",
              "token_revokation_endpoint"]
 
 logger = logging.getLogger(__name__)
-LOG_INFO = logger.info
-LOG_DEBUG = logger.debug
 
 
 def stateID(url, seed):
@@ -184,7 +183,7 @@ class Consumer(Client):
         :return: A URL to which the user should be redirected
         """
 
-        LOG_DEBUG("- begin -")
+        logger.debug("- begin -")
 
         # Store the request and the redirect uri used
         self.redirect_uris = ["%s%s" % (baseurl, self.authz_page)]
@@ -209,7 +208,7 @@ class Consumer(Client):
             AuthorizationRequest, method="GET", scope=self.scope,
             request_args={"state": sid, "response_type": response_type})[0]
 
-        LOG_DEBUG("Redirecting to: %s" % (location,))
+        logger.debug("Redirecting to: %s" % (sanitize(location),))
 
         return sid, location
 
@@ -223,8 +222,8 @@ class Consumer(Client):
         :return: A AccessTokenResponse instance
         """
 
-        LOG_DEBUG("- authorization - %s flow -" % self.flow_type)
-        LOG_DEBUG("QUERY: %s" % query)
+        logger.debug("- authorization - %s flow -" % self.flow_type)
+        logger.debug("QUERY: %s" % sanitize(query))
 
         if "code" in self.response_type:
             # Might be an error response

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -20,6 +20,7 @@ from oic.exception import PyoidcError
 from oic.exception import MessageException
 from oic.oauth2.exception import VerificationError
 from oic.utils.keyio import update_keyjar, issuer_keys
+from oic.utils.sanitize import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -467,8 +468,8 @@ class Message(object):
 
     def _add_key(self, keyjar, issuer, key, key_type=''):
         try:
-            logger.debug('keys for "{}": {}'.format(
-                issuer, issuer_keys(keyjar, issuer)))
+            n_keys = len(issuer_keys(keyjar, issuer))
+            logger.debug('{} keys for "{}"'.format(n_keys, issuer))
         except KeyError:
             logger.error('Issuer "{}" not in keyjar'.format(issuer))
 
@@ -589,8 +590,8 @@ class Message(object):
                 jso = _jwt.payload()
                 _header = _jwt.headers
 
-                logger.debug("Raw JSON: {}".format(jso))
-                logger.debug("header: {}".format(_header))
+                logger.debug("Raw JSON: {}".format(sanitize(jso)))
+                logger.debug("header: {}".format(sanitize(_header)))
                 if _header["alg"] == "none":
                     pass
                 elif verify:
@@ -603,7 +604,7 @@ class Message(object):
                             raise MissingSigningKey(
                                 "alg=%s" % _header["alg"])
 
-                    logger.debug("Verify keys: {}".format(key))
+                    logger.debug("Found signing key.")
                     try:
                         _jw.verify_compact(txt, key)
                     except NoSuitableSigningKeys:

--- a/src/oic/oauth2/message.py
+++ b/src/oic/oauth2/message.py
@@ -1,3 +1,4 @@
+from collections import MutableMapping
 import copy
 import logging
 import json
@@ -123,7 +124,7 @@ def jwt_header(txt):
     return json.loads(b64d(str(txt.split(".")[0])))
 
 
-class Message(object):
+class Message(MutableMapping):
     c_param = {}
     c_default = {}
     c_allowed_values = {}
@@ -136,6 +137,9 @@ class Message(object):
         self.jwe_header = None
         self.from_dict(kwargs)
         self.verify_ssl = True
+
+    def __iter__(self):
+        return iter(self._dict)
 
     def type(self):
         return self.__class__.__name__

--- a/src/oic/oauth2/util.py
+++ b/src/oic/oauth2/util.py
@@ -2,6 +2,7 @@ import logging
 
 from oic.oauth2.exception import TimeFormatError
 from oic.exception import UnSupported
+from oic.utils.sanitize import sanitize
 
 from six import string_types
 import six.moves.http_cookiejar as cookielib
@@ -123,7 +124,7 @@ def set_cookie(cookiejar, kaka):
             # Ignore cookie
             logger.info(
                 "Time format error on %s parameter in received cookie" % (
-                    attr,))
+                    sanitize(attr),))
             continue
 
         for att, spec in PAIRS.items():
@@ -165,8 +166,8 @@ def match_to_(val, vlist):
 
 
 def verify_header(reqresp, body_type):
-    logger.debug("resp.headers: %s" % (reqresp.headers,))
-    logger.debug("resp.txt: %s" % (reqresp.text,))
+    logger.debug("resp.headers: %s" % (sanitize(reqresp.headers),))
+    logger.debug("resp.txt: %s" % (sanitize(reqresp.text),))
 
     if body_type == "":
         _ctype = reqresp.headers["content-type"]

--- a/src/oic/oic/claims_provider.py
+++ b/src/oic/oic/claims_provider.py
@@ -23,6 +23,7 @@ from oic.oauth2.message import REQUIRED_LIST_OF_STRINGS
 
 from oic.utils.http_util import Response
 from oic.utils.authn.client import bearer_auth
+from oic.utils.sanitize import sanitize
 
 # Used in claims.py
 # from oic.oic.message import RegistrationRequest
@@ -101,7 +102,7 @@ class ClaimsServer(Provider):
                                                    algorithm="RS256"),
                                    claims_names=list(info.keys()))
 
-        logger.info("RESPONSE: %s" % (cresp.to_dict(),))
+        logger.info("RESPONSE: %s" % (sanitize(cresp.to_dict()),))
         return cresp
 
     #noinspection PyUnusedLocal
@@ -123,7 +124,7 @@ class ClaimsServer(Provider):
 
         ucreq = self.srvmethod.parse_user_claims_request(request)
 
-        _log_info("request: %s" % ucreq)
+        _log_info("request: %s" % sanitize(ucreq))
 
         try:
             resp = self.client_authn(self, ucreq, http_authz)
@@ -138,13 +139,13 @@ class ClaimsServer(Provider):
         else:
             uic = None
 
-        _log_info("User info claims: %s" % uic)
+        _log_info("User info claims: %s" % sanitize(uic))
 
         #oicsrv, userdb, subject, client_id="", user_info_claims=None
         info = self.userinfo(ucreq["sub"], user_info_claims=uic,
                              client_id=ucreq["client_id"])
 
-        _log_info("User info: %s" % info)
+        _log_info("User info: %s" % sanitize(info))
 
         # Convert to message format
         info = OpenIDSchema(**info)
@@ -154,23 +155,23 @@ class ClaimsServer(Provider):
         else:
             cresp = self._distributed(info)
 
-        _log_info("response: %s" % cresp.to_dict())
+        _log_info("response: %s" % sanitize(cresp.to_dict()))
 
         return Response(cresp.to_json(), content="application/json")
 
     def claims_info_endpoint(self, request, authn):
         _log_info = logger.info
 
-        _log_info("Claims_info_endpoint query: '%s'" % request)
+        _log_info("Claims_info_endpoint query: '%s'" % sanitize(request))
 
         ucreq = self.srvmethod.parse_userinfo_claims_request(request)
-        #_log_info("request: %s" % ucreq)
+        #_log_info("request: %s" % sanitize(ucreq))
 
         # Bearer header or body
         access_token = bearer_auth(ucreq, authn)
         uiresp = OpenIDSchema(**self.info_store[access_token])
 
-        _log_info("returning: %s" % uiresp.to_dict())
+        _log_info("returning: %s" % sanitize(uiresp.to_dict()))
         return Response(uiresp.to_json(), content="application/json")
 
 

--- a/src/oic/oic/consumer.py
+++ b/src/oic/oic/consumer.py
@@ -7,6 +7,7 @@ from hashlib import md5
 from oic import rndstr
 from oic.exception import PyoidcError
 from oic.utils import http_util
+from oic.utils.sanitize import sanitize
 from oic.oic import Client
 from oic.oic import ENDPOINTS
 from oic.oic.message import Claims, ClaimsRequest
@@ -314,10 +315,10 @@ class Consumer(Client):
                                     sformat="urlencoded",
                                     keyjar=self.keyjar)
         if isinstance(aresp, ErrorResponse):
-            _log_info("ErrorResponse: %s" % aresp)
+            _log_info("ErrorResponse: %s" % sanitize(aresp))
             raise AuthzError(aresp.get('error'), aresp)
 
-        _log_info("Aresp: %s" % aresp)
+        _log_info("Aresp: %s" % sanitize(aresp))
 
         _state = aresp["state"]
         try:
@@ -350,7 +351,7 @@ class Consumer(Client):
         if not query:
             return http_util.BadRequest("Missing query")
 
-        _log_info("response: %s" % query)
+        _log_info("response: %s" % sanitize(query))
 
         if "code" in self.consumer_config["response_type"]:
             aresp, _state = self._parse_authz(query, **kwargs)
@@ -413,7 +414,7 @@ class Consumer(Client):
                                             request_args=args,
                                             http_args=http_args)
 
-        logger.info("Access Token Response: %s" % resp)
+        logger.info("Access Token Response: %s" % sanitize(resp))
 
         if resp.type() == "ErrorResponse":
             raise TokenError(resp.error, resp)

--- a/src/oic/utils/authn/authn_context.py
+++ b/src/oic/utils/authn/authn_context.py
@@ -128,9 +128,9 @@ class AuthnBroker(object):
                             _val = (_dic["level"], _dic["method"], _dic["ref"])
                             if _val not in res:
                                 res_other.append(_val)
-            # sort on level
-            res_other.sort(key=cmp_to_key(self._cmp), reverse=True)
             res.extend(res_other)
+            # sort on level
+            res.sort(key=cmp_to_key(self._cmp), reverse=True)
 
             return [(b, c) for a, b, c in res]
 

--- a/src/oic/utils/authn/client.py
+++ b/src/oic/utils/authn/client.py
@@ -19,7 +19,9 @@ from oic.oic import REQUEST2ENDPOINT
 from oic.oic import DEF_SIGN_ALG
 from oic.oic import AuthnToken
 from oic.oic import JWT_BEARER
+from oic.utils.sanitize import sanitize
 from oic.utils.time_util import utc_time_sans_frac
+
 
 logger = logging.getLogger(__name__)
 
@@ -316,7 +318,7 @@ class JWSAuthnMethod(ClientAuthnMethod):
             else:
                 signing_key = self.get_signing_key(algorithm)
         except NoMatchingKey as err:
-            logger.error("%s" % err)
+            logger.error("%s" % sanitize(err))
             raise SystemError()
 
         if 'client_assertion' in kwargs:
@@ -358,13 +360,13 @@ class JWSAuthnMethod(ClientAuthnMethod):
             bjwt = AuthnToken().from_jwt(areq["client_assertion"],
                                          keyjar=self.cli.keyjar)
         except (Invalid, MissingKey) as err:
-            logger.info("%s" % err)
+            logger.info("%s" % sanitize(err))
             raise AuthnFailure("Could not verify client_assertion.")
 
-        logger.debug("authntoken: %s" % bjwt.to_dict())
+        logger.debug("authntoken: %s" % sanitize(bjwt.to_dict()))
         areq['parsed_client_assertion'] = bjwt
 
-        # logger.debug("known clients: %s" % self.cli.cdb.keys())
+        # logger.debug("known clients: %s" % sanitize(self.cli.cdb.keys()))
         try:
             cid = kwargs["client_id"]
         except KeyError:
@@ -460,7 +462,7 @@ def get_client_id(cdb, req, authn):
     :return:
     """
 
-    logger.debug("REQ: %s" % req.to_dict())
+    logger.debug("REQ: %s" % sanitize(req.to_dict()))
     if authn:
         if authn.startswith("Basic "):
             logger.debug("Basic auth")

--- a/src/oic/utils/authz.py
+++ b/src/oic/utils/authz.py
@@ -3,6 +3,7 @@ import time
 
 from oic.utils.http_util import CookieDealer
 from oic.utils.authn.user import ToOld
+from oic.utils.sanitize import sanitize
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ class AuthzHandling(CookieDealer):
         if cookie is None:
             return None
         else:
-            logger.debug("kwargs: %s" % kwargs)
+            logger.debug("kwargs: %s" % sanitize(kwargs))
 
             val = self.getCookieValue(cookie, self.srv.cookie_name)
             if val is None:

--- a/src/oic/utils/keyio.py
+++ b/src/oic/utils/keyio.py
@@ -385,6 +385,11 @@ class KeyJar(object):
         self.verify_ssl = verify_ssl
         self.keybundle_cls = keybundle_cls
 
+    def __repr__(self):
+        issuers = list(self.issuer_keys.keys())
+        return '<KeyJar(issuers={})>'.format(issuers)
+
+
     def add_if_unique(self, issuer, use, keys):
         if use in self.issuer_keys[issuer] and self.issuer_keys[issuer][use]:
             for typ, key in keys:

--- a/src/oic/utils/sanitize.py
+++ b/src/oic/utils/sanitize.py
@@ -1,0 +1,47 @@
+from collections import Mapping
+from textwrap import dedent
+import re
+
+
+SENSITIVE_THINGS = {'password', 'passwd', 'client_secret', 'code',
+                    'authorization', 'access_token', 'refresh_token'}
+
+
+REPLACEMENT = '<REDACTED>'
+
+
+SANITIZE_PATTERN = r'''
+    (?<!_) # Negative-lookbehind for underscore.
+    # Necessary to keep 'authorization_code' from matching 'code'
+    ( # Start of capturing group--we'll keep this bit.
+         (?: # non-capturing group
+             {} # Template-in things we want to sanitize
+         ) #
+        ['\"]? # Might have a quote after them?
+        \s* # Maybe some whitespace
+        [=:,] # Probably a : , or = in tuple, dict or qs format
+        \s* # Maybe more whitespace
+        [([]? # Could be inside a list/tuple, parse_qs?
+        [ub]? # Python 2/3
+        [\"']? # Might be a quote here.
+    ) # End of capturing group
+    (?:[%=/+\w]+) # This is the bit we replace with '<REDACTED>'
+'''
+
+SANITIZE_PATTERN = dedent(SANITIZE_PATTERN.format('|'.join(SENSITIVE_THINGS)))
+SANITIZE_REGEX = re.compile(SANITIZE_PATTERN, re.VERBOSE|re.IGNORECASE)
+
+def redacted(key, value):
+    if key in SENSITIVE_THINGS:
+        return (key, REPLACEMENT)
+    return (key, value)
+
+def sanitize(potentially_sensitive):
+    if isinstance(potentially_sensitive, Mapping):
+        # Makes new dict so we don't modify the original
+        # Also case-insensitive--possibly important for HTTP headers.
+        return dict(redacted(k.lower(), v) for k, v in potentially_sensitive.items())
+    else:
+        potentially_sensitive = str(potentially_sensitive)
+        return SANITIZE_REGEX.sub(r'\1{}'.format(REPLACEMENT),
+                                  potentially_sensitive)

--- a/src/oic/utils/userinfo/distaggr.py
+++ b/src/oic/utils/userinfo/distaggr.py
@@ -5,6 +5,7 @@ from oic.exception import MissingAttribute
 from oic.oic import OpenIDSchema
 from oic.oic.claims_provider import ClaimsClient
 from oic.utils.userinfo import UserInfo
+from oic.utils.sanitize import sanitize
 
 
 __author__ = 'rolandh'
@@ -122,9 +123,10 @@ class DistributedAggregatedUserInfo(UserInfo):
 
                 for srv, what in cpoints.items():
                     cc = self.oidcsrv.claims_clients[srv]
-                    logger.debug("srv: %s, what: %s" % (srv, what))
+                    logger.debug("srv: %s, what: %s" % (sanitize(srv),
+                                                        sanitize(what)))
                     _res = self._collect_distributed(srv, cc, userid, what)
-                    logger.debug("Got: %s" % _res)
+                    logger.debug("Got: %s" % sanitize(_res))
                     for key, val in _res.items():
                         if key in result:
                             result[key].update(val)

--- a/src/oic/utils/userinfo/ldap_info.py
+++ b/src/oic/utils/userinfo/ldap_info.py
@@ -2,6 +2,7 @@ import logging
 import ldap
 
 from oic.utils.userinfo import UserInfo
+from oic.utils.sanitize import sanitize
 
 
 __author__ = 'rolandh'
@@ -60,7 +61,7 @@ class UserInfoLDAP(UserInfo):
     def __call__(self, userid, client_id, user_info_claims=None,
                  first_only=True, **kwargs):
         _filter = self.filter_pattern % userid
-        logger.debug("CLAIMS: %s" % user_info_claims)
+        logger.debug("CLAIMS: %s" % sanitize(user_info_claims))
         _attr = self.attr
         if user_info_claims:
             try:

--- a/tests/test_oauth2_provider.py
+++ b/tests/test_oauth2_provider.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import time
 import pytest
 import six
+from testfixtures import LogCapture
 
 from future.backports.urllib.parse import urlparse
 from future.backports.urllib.parse import parse_qs
@@ -135,13 +137,27 @@ class TestProvider(object):
         resp = self.provider.authorization_endpoint(urlparse(location).query)
         assert resp.status == "303 See Other"
         resp = urlparse(resp.message).query
-        aresp = cons.handle_authorization_response(query=resp)
+        with LogCapture(level=logging.DEBUG) as logcap:
+            aresp = cons.handle_authorization_response(query=resp)
 
         assert isinstance(aresp, AuthorizationResponse)
         assert _eq(aresp.keys(), ['state', 'code', 'client_id', 'iss'])
         assert _eq(cons.grant[sid].keys(), ['tokens', 'code', 'exp_in',
                                             'seed', 'id_token',
                                             'grant_expiration_time'])
+
+        state = aresp['state']
+        assert _eq(logcap.records[0].msg, '- authorization - code flow -')
+        expected = 'QUERY: iss=https%3A%2F%2Fexample.com%2Fas&state={}&code=<REDACTED>&client_id=client1'.format(state)
+        assert _eq(logcap.records[1].msg, expected)
+        expected = {'iss': 'https://example.com/as',
+                    'state': state, 'code': '<REDACTED>',
+                    'client_id': 'client1'}
+        # Eval here to avoid intermittent failures due to dict ordering
+        assert _eq(eval(logcap.records[2].msg[29:-1]), expected)
+        expected = ["'client_id': 'client1'", "'iss': 'https://example.com/as'",
+                    "'keyjar': <KeyJar(issuers=[])>"]
+        assert _eq(sorted(logcap.records[3].msg[22:-1].split(', ')), expected)
 
     def test_authenticated_token(self):
         _session_db = {}
@@ -183,10 +199,34 @@ class TestProvider(object):
                                   client_id="client1",
                                   client_secret="hemlighet",
                                   grant_type='authorization_code')
-
-        resp = self.provider.token_endpoint(request=areq.to_urlencoded())
+        with LogCapture(level=logging.DEBUG) as logcap:
+            resp = self.provider.token_endpoint(request=areq.to_urlencoded())
         atr = AccessTokenResponse().deserialize(resp.message, "json")
         assert _eq(atr.keys(), ['access_token', 'token_type', 'refresh_token'])
+
+        expected = ('body: code=<REDACTED>&client_secret=<REDACTED>&grant_type=authorization_code'
+                '   &client_id=client1&redirect_uri=http%3A%2F%2Fexample.com%2Fauthz')
+        assert _eq(parse_qs(logcap.records[1].msg[6:]), parse_qs(expected[6:]))
+        expected = {u'code': '<REDACTED>', u'client_secret': '<REDACTED>',
+                    u'redirect_uri': u'http://example.com/authz', u'client_id': 'client1',
+                    u'grant_type': 'authorization_code'}
+        # Don't try this at home, kids!
+        # We have to eval() to a dict here because otherwise the arbitrary
+        # ordering of the string causes the test to fail intermittently.
+        assert _eq(eval(logcap.records[2].msg[4:]), expected)
+        assert _eq(logcap.records[3].msg, 'Verified Client ID: client1')
+        expected = {'redirect_uri': u'http://example.com/authz', 'client_secret': '<REDACTED>',
+                    'code': u'<REDACTED>', 'client_id': 'client1', 'grant_type': 'authorization_code'}
+        assert eval(logcap.records[4].msg[20:]) == expected
+        expected = {'code': '<REDACTED>', 'authzreq': '', 'sub': 'sub', 'access_token': '<REDACTED>',
+                    'token_type': 'Bearer', 'redirect_uri': 'http://example.com/authz',
+                    'code_used': True, 'client_id': 'client1', 'oauth_state': 'token',
+                    'refresh_token': '<REDACTED>', 'access_token_scope': '?'}
+        assert _eq(eval(logcap.records[5].msg[7:]), expected)
+        expected = {'access_token': u'<REDACTED>', 'token_type': 'Bearer',
+                    'refresh_token': '<REDACTED>'}
+        assert _eq(eval(logcap.records[6].msg[21:]), expected)
+
 
     def test_token_endpoint_unauth(self):
         authreq = AuthorizationRequest(state="state",

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 httpretty==0.8.10
 mock
+testfixtures

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,47 @@
+import pytest
+
+from oic.oauth2.message import AccessTokenRequest
+from oic.utils.sanitize import sanitize
+
+
+@pytest.mark.parametrize("raw,expected", [
+
+    ('code=%5B999%5D&bing=baz&password=foo&param1=bar',
+     'code=<REDACTED>&bing=baz&password=<REDACTED>&param1=bar'),
+
+    (AccessTokenRequest(grant_type='authorization_code', redirect_uri=u'http://example.com/authz',
+                        client_id='client1', client_secret='hemlighet',
+                        code=u'0x+QZlw/S2O9NJKVqB/LDzzhod4v/FVh6ULK/0OnFsfOFRQcux5ow=='),
+
+     {'grant_type': 'authorization_code', 'redirect_uri': u'http://example.com/authz',
+      'client_id': 'client1', 'client_secret': '<REDACTED>', 'code': u'<REDACTED>'}
+
+    ),
+
+    (
+        ("{'grant_type': 'authorization_code', 'redirect_uri': u'http://example.com/authz', "
+         "'client_id': 'client1', 'client_secret': 'hemlighet', "
+         "'code': u'0x+QZlw/S2O9NJKVqB/LDzzhod4v/FVh6ULK/0OnFsfOFRQcux5ow=='}"),
+
+        ("{'grant_type': 'authorization_code', 'redirect_uri': u'http://example.com/authz', "
+         "'client_id': 'client1', 'client_secret': '<REDACTED>', 'code': u'<REDACTED>'}")
+    ),
+
+    ({'Password': 'foo', 'param1': 'bar', 'CODE': [999], 'bing': 'baz'},
+     {'bing': 'baz', 'code': '<REDACTED>', 'param1': 'bar', 'password': '<REDACTED>'}),
+
+    ("{'code': [999], 'bing': 'baz', 'password': 'foo', 'param1': 'bar'}",
+     "{'code': [<REDACTED>], 'bing': 'baz', 'password': '<REDACTED>', 'param1': 'bar'}"),
+
+     ([('code', [999]), ('bing', 'baz'), ('password', 'foo'), ('param1', 'bar')],
+      "[('code', [<REDACTED>]), ('bing', 'baz'), ('password', '<REDACTED>'), ('param1', 'bar')]")
+])
+
+def test_sanitize(raw, expected):
+    assert sanitize(raw) == expected
+
+def test_sanitize_preserves_original():
+    old = {'passwd': 'secret'}
+    new = sanitize(old)
+    assert old['passwd'] == 'secret'
+    assert new['passwd'] == '<REDACTED>'

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27,py34
 
 [testenv]
-commands = py.test tests/ -m "not network"
+commands = py.test tests/ -m "not network" {posargs}
 deps = -rtests/test_requirements.txt
 
 [pep8]


### PR DESCRIPTION
Fixes #228

- Adds `oic.utils.sanitize.sanitize()` function that makes a best-effort attempt to remove sensitive data from mappings and strings. 
- Applies `sanitize()` throughout the codebase on log entries.
- Removes or modifies some log entries I wasn't confident could be sanitized, or that seemed like they would be uninformative after sanitizing. 
- Makes `oic.oauth2.message.Message` into a subclass of `MutableMapping` to make life easier for the `sanitize()` function.
- Adds a nicer `__repr__()` for the `KeyJar` to make testing easier.
- Slightly changes sorting behavior on `authn_context` to get consistent test output.
- Adds tests for `sanitize()`
- Extends some existing tests to verify their logs are clean.
- Modifies tox.ini to allow passing extra arguments in to the test runner.