### PR TITLE
Travis CI: test against CPython 3.4.4 and 3.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ addons:
 
 matrix:
   include:
-    - python: 3.5.0
+    - python: 3.5.2
       env: TOXENV=py35
-    - python: 3.4.3
+    - python: 3.4.4
       env: TOXENV=py34
     - python: 2.7
       env: TOXENV=py27


### PR DESCRIPTION
We should test against the latest point releases. Especially in case of Python 3.5 (the changes between 3.5.0 and 3.5.2 are significant).
