### PR TITLE
examples: make static file handlers return bytes instead of text

### DIFF
--- a/oidc_example/op1/oc_server.py
+++ b/oidc_example/op1/oc_server.py
@@ -295,7 +295,7 @@ def static(environ, start_response, logger, path):
     logger.info("[static]sending: %s" % (path,))
 
     try:
-        text = open(path).read()
+        data = open(path, 'rb').read()
         if path.endswith(".ico"):
             start_response('200 OK', [('Content-Type', "image/x-icon")])
         elif path.endswith(".html"):
@@ -308,7 +308,7 @@ def static(environ, start_response, logger, path):
             start_response('200 OK', [('Content-Type', 'text/css')])
         else:
             start_response('200 OK', [('Content-Type', "text/xml")])
-        return [text]
+        return [data]
     except IOError:
         resp = NotFound()
         return resp(environ, start_response)

--- a/oidc_example/op2/server.py
+++ b/oidc_example/op2/server.py
@@ -236,7 +236,7 @@ def static(environ, start_response, path):
     logger.info("[static]sending: %s" % (path,))
 
     try:
-        text = open(path).read()
+        data = open(path, 'rb').read()
         if path.endswith(".ico"):
             start_response('200 OK', [('Content-Type', "image/x-icon")])
         elif path.endswith(".html"):
@@ -249,7 +249,7 @@ def static(environ, start_response, path):
             start_response('200 OK', [('Content-Type', 'text/css')])
         else:
             start_response('200 OK', [('Content-Type', "text/xml")])
-        return [text]
+        return [data]
     except IOError:
         resp = NotFound()
         return resp(environ, start_response)

--- a/oidc_example/rp2/rp2.py
+++ b/oidc_example/rp2/rp2.py
@@ -62,7 +62,7 @@ class Session(object):
     def __getitem__(self, item):
         if item == 'state':
             return uuid.uuid4().urn
-        
+
         try:
             return self.session[item]
         except KeyError:
@@ -70,7 +70,7 @@ class Session(object):
 
     def __setitem__(self, key, value):
         self.session[key] = value
-        
+
     def clear(self):
         for key in list(self.session.keys()):
             del self.session[key]
@@ -93,7 +93,7 @@ def static(environ, start_response, logger, path):
     logger.info("[static]sending: %s" % (path,))
 
     try:
-        text = open(path).read()
+        data = open(path, 'rb').read()
         if path.endswith(".ico"):
             start_response('200 OK', [('Content-Type', "image/x-icon")])
         elif path.endswith(".html"):
@@ -106,7 +106,7 @@ def static(environ, start_response, logger, path):
             start_response('200 OK', [('Content-Type', 'text/css')])
         else:
             start_response('200 OK', [('Content-Type', "text/xml")])
-        return [text]
+        return [data]
     except IOError:
         resp = NotFound()
         return resp(environ, start_response)

--- a/oidc_example/rp3/rp3.py
+++ b/oidc_example/rp3/rp3.py
@@ -70,7 +70,7 @@ def static(environ, start_response, logger, path):
     logger.info("[static]sending: %s" % (path,))
 
     try:
-        text = open(path).read()
+        data = open(path, 'rb').read()
         if path.endswith(".ico"):
             start_response('200 OK', [('Content-Type', "image/x-icon")])
         elif path.endswith(".html"):
@@ -83,7 +83,7 @@ def static(environ, start_response, logger, path):
             start_response('200 OK', [('Content-Type', 'text/css')])
         else:
             start_response('200 OK', [('Content-Type', "text/xml")])
-        return [text]
+        return [data]
     except IOError:
         resp = NotFound()
         return resp(environ, start_response)


### PR DESCRIPTION
This addresses https://github.com/rohe/pyoidc/issues/232