### PR TITLE
oauth2/base: consolidate usage of requests arguments for server cert verification.

### DIFF
--- a/src/oic/oauth2/base.py
+++ b/src/oic/oauth2/base.py
@@ -26,10 +26,26 @@ class PBase(object):
         # self.cookies = {}
         self.cookiejar = cookielib.FileCookieJar()
         self.ca_certs = ca_certs
+
         if ca_certs:
-            self.request_args["verify"] = verify_ssl
+            if verify_ssl is False:
+                raise ValueError(
+                    'conflict: ca_certs defined, but verify_ssl is False')
+
+            # Instruct requests to verify certificate against the CA cert
+            # bundle located at the path given by `ca_certs`.
+            self.request_args["verify"] = ca_certs
+
+        elif verify_ssl:
+            # Instruct requests to verify server certificates against the
+            # default CA bundle provided by 'certifi'. See
+            # http://docs.python-requests.org/en/master/user/advanced/#ca-certificates
+            self.request_args["verify"] = True
+
         else:
+            # Instruct requests to n ot perform server cert verification.
             self.request_args["verify"] = False
+
         self.event_store = None
         self.req_callback = None
 


### PR DESCRIPTION
The current code in PBase does not respect `verify_ssl` set to True:

```
         if ca_certs:
            self.request_args["verify"] = verify_ssl
```

That is, it only sets `request_args["verify"]` to `True` if `ca_certs` evaluates to True (`verify_ssl` is effectively ignored).

That code also does not respect `ca_certs`, if given (because if it is given, the underlying requests argument is not populated with `ca_certs`).

This PR improves the handling of the pyoidc-specific HTTP client args `verify_ssl` and `ca_certs`, and translates them into the expected `verify` argument value of the requests package.