### PR TITLE
Catching UnknownClient in auth_init

### DIFF
--- a/src/oic/oauth2/provider.py
+++ b/src/oic/oauth2/provider.py
@@ -401,7 +401,7 @@ class Provider(object):
             areq = request_class().deserialize(request, "urlencoded")
             try:
                 redirect_uri = self.get_redirect_uri(areq)
-            except (RedirectURIError, ParameterError) as err:
+            except (RedirectURIError, ParameterError, UnknownClient) as err:
                 return self._error("invalid_request", "%s" % err)
             try:
                 _rtype = areq["response_type"]

--- a/tests/test_oauth2_provider.py
+++ b/tests/test_oauth2_provider.py
@@ -126,6 +126,15 @@ class TestProvider(object):
         msg = json.loads(resp.message)
         assert msg["error"] == "invalid_request"
 
+    def test_authorization_endpoint_missing_client_id(self):
+        # Url encoded request with missing client_id
+        arq = 'scope=openid&state=id-6da9ca0cc23959f5f33e8becd9b08cae&'\
+              'redirect_uri=+https%3A%2F%2Fexample.com&response_type=code'
+        resp = self.provider.authorization_endpoint(request=arq)
+        assert resp.status == "400 Bad Request"
+        msg = json.loads(resp.message)
+        assert msg["error"] == "invalid_request"
+
     def test_authenticated(self):
         _session_db = {}
         cons = Consumer(_session_db, client_config=CLIENT_CONFIG,


### PR DESCRIPTION
`get_redirect_uri` can throw `UnknownClient` when `client_id` is missing either in request or in client database.