### PR TITLE
Reraise logged Exception in parse_authorization_request

### DIFF
--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1501,6 +1501,7 @@ class Server(oauth2.Server):
             if self.events:
                 self.events.store('Exception', err)
             logger.error(err)
+            raise
 
         return _req
 

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -266,6 +266,20 @@ class TestProvider(object):
 
         assert resp.message.startswith("http://localhost:8087/authz")
 
+    def test_authorization_endpoint_bad_scope(self):
+        bib = {"scope": ["openid", "offline_access"],
+               "state": "id-6da9ca0cc23959f5f33e8becd9b08cae",
+               "redirect_uri": "http://localhost:8087/authz",
+               "response_type": ["code"],
+               "client_id": "a1b2c3"}
+
+        arq = AuthorizationRequest(**bib)
+        resp = self.provider.authorization_endpoint(request=arq.to_urlencoded())
+        assert resp.status == "303 See Other"
+        parsed = parse_qs(urlparse(resp.message).query)
+        assert parsed["error"][0] == "invalid_request"
+        assert parsed["error_description"][0] == "consent in prompt"
+
     def test_authenticated(self):
         _state, location = self.cons.begin("openid", "code",
                                            path="http://localhost:8087")


### PR DESCRIPTION
This was hiding errors in message and allowed them to resurface when not expected.
Example of this is offline_acces without prompt.