### PR TITLE
Add Python3 compatible LDAP replacement.

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -110,7 +110,7 @@ For running the tests you will additionally need to install:
 
 If you wish your LDAP tests to pass, ensure you have installed the following package as well:
 
-* python-ldap (not supported in windows)
+* pyldap (not supported in windows)
 
 Debian/Mac
 ==========

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ mako>=1.0.0
 beaker>=1.6.4
 alabaster==0.6.2
 pyOpenSSL>=0.14
-python-ldap>=2.4.10
+pyldap>=2.4.25.1

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -3,3 +3,4 @@ httpretty==0.8.10
 responses
 mock
 testfixtures
+pyldap


### PR DESCRIPTION
`python-ldap` kinda holds the Python 2/3 compatibility back.

`pyldap` is *supposed to be* a drop-in replacement fork. 

Let's see what Travis CI says.