### PR TITLE
Update documentation: compat and byte compiling note.

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -111,6 +111,10 @@ If you wish your LDAP tests to pass, ensure you have installed the following pac
 
 * python-ldap (not supported in windows)
 
+.. note:: The depdencies will require you compile your Python source code
+          with byte-compiling. This means avoiding the `-B` option or
+          not setting `PYTHONDONTWRITEBYTECODE`.
+
 Debian/Mac
 ==========
 If you don't want to install pyoidc and all it's dependencies manually you can use yais

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -73,8 +73,7 @@ Install PyOIDC
 ==============
 
 For all this to work you need to have Python installed.
-The development has been done using 2.7.
-There will shortly be a 3.4 version.
+PyOIDC supports Python 2 and 3.
 
 Prerequisites
 =============


### PR DESCRIPTION
I ran into a really nasty `pycryptodome` bug that was the result of ignoring bye-compiling. 

Here's a note so nobody else will fall into that (hopefully!).